### PR TITLE
Specify and implement error messages for complex table differences

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,48 @@ Output is like the following:
 
 ![Example Output](resources/example-output.gif)
 
+## Error Message Specification
+
+When tables are unequal, the assertion throws a detailed error message with labeled sections.
+
+### Difference sections
+
+- `--- Missing rows`: Rows present in expected but not in actual.
+- `+++ Unexpected rows`: Rows present in actual but not in expected.
+- `*** Duplicate rows`: Rows present on both sides with different multiplicity, shown as `(appears N time/times, expected M)`.
+
+### Row-order diagnostics
+
+When row order is respected and rows are out of order:
+
+- `*** Row order mismatch` is shown.
+- Per-row diagnostics are listed as `... should be at position X, found at Y`.
+- Full order context is appended under:
+    - `Expected order`
+    - `Actual order`
+
+When row content differs while respecting row order, semantic missing/unexpected/duplicate sections are shown first, then full expected/actual order tables.
+
+### Header mismatch diagnostics
+
+When `expectHeader(...)` is used and the first row does not match:
+
+- `--- Expected header`
+- `+++ Given header`
+
+### Label customization
+
+All user-facing section labels are configurable via defaults plus getter/setter pairs:
+
+- Missing rows
+- Unexpected rows
+- Duplicate rows
+- Row order mismatch
+- Expected header
+- Given header
+- Expected order subheading
+- Actual order subheading
+
 ## Examples
 
 See [`features/bootstrap/FeatureContext.php`](features/bootstrap/FeatureContext.php) and [`features/examples.feature`](features/examples.feature) for more examples.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ class FeatureContext implements Context
             ->ignoreRowOrder()
             ->setMissingRowsLabel('Missing characters')
             ->setUnexpectedRowsLabel('Unexpected characters')
+            ->setDuplicateRowsLabel('Duplicate characters')
             ->assert();
     }
 

--- a/README.md
+++ b/README.md
@@ -65,10 +65,6 @@ Output is like the following:
 
 See [`features/bootstrap/FeatureContext.php`](features/bootstrap/FeatureContext.php) and [`features/examples.feature`](features/examples.feature) for more examples.
 
-## Limitations & Known Issues
-
-Some inequality detection currently works but does not yet display a helpful error message, because it has not been decided what it should show. Please help me [specify error messages for complex differences](https://github.com/TravisCarden/behat-table-comparison/issues/1).
-
 ## Contribution
 
 All contributions are welcome according to [normal open source practice](https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution).

--- a/src/BehatTableComparison/TableEqualityAssertion.php
+++ b/src/BehatTableComparison/TableEqualityAssertion.php
@@ -3,7 +3,6 @@
 namespace TravisCarden\BehatTableComparison;
 
 use Behat\Gherkin\Node\TableNode;
-use SebastianBergmann\Diff\Differ;
 
 /**
  * Asserts equality between two TableNodes.
@@ -283,9 +282,8 @@ class TableEqualityAssertion
                 throw new UnequalTablesException($message);
             }
 
-            $diff = (new Differ("--- Expected\n+++ Actual\n"))
-                ->diff($expected_body, $actual_body);
-            throw new UnequalTablesException($diff);
+            $message = $this->generateMessageForContentAndOrderDifferences($expected_body_rows, $actual_body_rows);
+            throw new UnequalTablesException($message);
         }
     }
 
@@ -472,6 +470,31 @@ class TableEqualityAssertion
                     $actual_position
                 );
             }
+        }
+
+        $message[] = 'Expected order:';
+        $message[] = (new TableNode($expected_rows))->getTableAsString();
+        $message[] = 'Actual order:';
+        $message[] = (new TableNode($actual_rows))->getTableAsString();
+
+        return implode(PHP_EOL, $message);
+    }
+
+    /**
+     * @param array $expected_rows
+     * @param array $actual_rows
+     *
+     * @return string
+     */
+    protected function generateMessageForContentAndOrderDifferences(array $expected_rows, array $actual_rows)
+    {
+        $sorted_expected = $this->sortTable(new TableNode($expected_rows))->getRows();
+        $sorted_actual = $this->sortTable(new TableNode($actual_rows))->getRows();
+
+        $message = [];
+        $content_message = $this->generateMessageForPostSortDifferences($sorted_expected, $sorted_actual);
+        if ($content_message) {
+            $message[] = $content_message;
         }
 
         $message[] = 'Expected order:';

--- a/src/BehatTableComparison/TableEqualityAssertion.php
+++ b/src/BehatTableComparison/TableEqualityAssertion.php
@@ -15,6 +15,10 @@ class TableEqualityAssertion
 
     const DEFAULT_UNEXPECTED_ROWS_LABEL = 'Unexpected rows';
 
+    const DEFAULT_DUPLICATE_ROWS_LABEL = 'Duplicate rows';
+
+    const DEFAULT_ROW_ORDER_MISMATCH_LABEL = 'Row order mismatch';
+
     /**
      * @var \Behat\Gherkin\Node\TableNode
      */
@@ -34,6 +38,16 @@ class TableEqualityAssertion
      * @var string
      */
     protected $unexpectedRowsLabel = self::DEFAULT_UNEXPECTED_ROWS_LABEL;
+
+    /**
+     * @var string
+     */
+    protected $duplicateRowsLabel = self::DEFAULT_DUPLICATE_ROWS_LABEL;
+
+    /**
+     * @var string
+     */
+    protected $rowOrderMismatchLabel = self::DEFAULT_ROW_ORDER_MISMATCH_LABEL;
 
     /**
      * @var array
@@ -108,6 +122,44 @@ class TableEqualityAssertion
     public function setUnexpectedRowsLabel(string $label)
     {
         $this->unexpectedRowsLabel = $label;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDuplicateRowsLabel()
+    {
+        return $this->duplicateRowsLabel;
+    }
+
+    /**
+     * @param string $label
+     *
+     * @return $this
+     */
+    public function setDuplicateRowsLabel(string $label)
+    {
+        $this->duplicateRowsLabel = $label;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRowOrderMismatchLabel()
+    {
+        return $this->rowOrderMismatchLabel;
+    }
+
+    /**
+     * @param string $label
+     *
+     * @return $this
+     */
+    public function setRowOrderMismatchLabel(string $label)
+    {
+        $this->rowOrderMismatchLabel = $label;
         return $this;
     }
 
@@ -300,7 +352,7 @@ class TableEqualityAssertion
             $message[] = (new TableNode($unexpected_rows))->getTableAsString();
         }
         if (!empty($duplicate_rows)) {
-            $message[] = '*** Duplicate rows';
+            $message[] = '*** ' . $this->getDuplicateRowsLabel();
             foreach ($duplicate_rows as $line) {
                 $message[] = $line;
             }
@@ -398,7 +450,7 @@ class TableEqualityAssertion
      */
     protected function generateMessageForRowOrderMismatch(array $expected_rows, array $actual_rows)
     {
-        $message = ['*** Row order mismatch'];
+        $message = ['*** ' . $this->getRowOrderMismatchLabel()];
         $expected_positions = $this->mapRowPositions($expected_rows);
         $actual_positions = $this->mapRowPositions($actual_rows);
 

--- a/src/BehatTableComparison/TableEqualityAssertion.php
+++ b/src/BehatTableComparison/TableEqualityAssertion.php
@@ -18,6 +18,14 @@ class TableEqualityAssertion
 
     const DEFAULT_ROW_ORDER_MISMATCH_LABEL = 'Row order mismatch';
 
+    const DEFAULT_EXPECTED_HEADER_LABEL = 'Expected header';
+
+    const DEFAULT_GIVEN_HEADER_LABEL = 'Given header';
+
+    const DEFAULT_EXPECTED_ORDER_LABEL = 'Expected order';
+
+    const DEFAULT_ACTUAL_ORDER_LABEL = 'Actual order';
+
     /**
      * @var \Behat\Gherkin\Node\TableNode
      */
@@ -47,6 +55,26 @@ class TableEqualityAssertion
      * @var string
      */
     protected $rowOrderMismatchLabel = self::DEFAULT_ROW_ORDER_MISMATCH_LABEL;
+
+    /**
+     * @var string
+     */
+    protected $expectedHeaderLabel = self::DEFAULT_EXPECTED_HEADER_LABEL;
+
+    /**
+     * @var string
+     */
+    protected $givenHeaderLabel = self::DEFAULT_GIVEN_HEADER_LABEL;
+
+    /**
+     * @var string
+     */
+    protected $expectedOrderLabel = self::DEFAULT_EXPECTED_ORDER_LABEL;
+
+    /**
+     * @var string
+     */
+    protected $actualOrderLabel = self::DEFAULT_ACTUAL_ORDER_LABEL;
 
     /**
      * @var array
@@ -163,6 +191,82 @@ class TableEqualityAssertion
     }
 
     /**
+     * @return string
+     */
+    public function getExpectedHeaderLabel()
+    {
+        return $this->expectedHeaderLabel;
+    }
+
+    /**
+     * @param string $label
+     *
+     * @return $this
+     */
+    public function setExpectedHeaderLabel(string $label)
+    {
+        $this->expectedHeaderLabel = $label;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getGivenHeaderLabel()
+    {
+        return $this->givenHeaderLabel;
+    }
+
+    /**
+     * @param string $label
+     *
+     * @return $this
+     */
+    public function setGivenHeaderLabel(string $label)
+    {
+        $this->givenHeaderLabel = $label;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExpectedOrderLabel()
+    {
+        return $this->expectedOrderLabel;
+    }
+
+    /**
+     * @param string $label
+     *
+     * @return $this
+     */
+    public function setExpectedOrderLabel(string $label)
+    {
+        $this->expectedOrderLabel = $label;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getActualOrderLabel()
+    {
+        return $this->actualOrderLabel;
+    }
+
+    /**
+     * @param string $label
+     *
+     * @return $this
+     */
+    public function setActualOrderLabel(string $label)
+    {
+        $this->actualOrderLabel = $label;
+        return $this;
+    }
+
+    /**
      * @return array
      */
     public function getExpectedHeader()
@@ -243,9 +347,9 @@ class TableEqualityAssertion
         }
 
         $message = [
-            '--- Expected header',
+            '--- ' . $this->getExpectedHeaderLabel(),
             (new TableNode([$expected_header]))->getTableAsString(),
-            '+++ Given',
+            '+++ ' . $this->getGivenHeaderLabel(),
             (new TableNode([$actual_header]))->getTableAsString(),
         ];
         throw new \LogicException(implode(PHP_EOL, $message));
@@ -472,9 +576,9 @@ class TableEqualityAssertion
             }
         }
 
-        $message[] = 'Expected order:';
+        $message[] = $this->getExpectedOrderLabel();
         $message[] = (new TableNode($expected_rows))->getTableAsString();
-        $message[] = 'Actual order:';
+        $message[] = $this->getActualOrderLabel();
         $message[] = (new TableNode($actual_rows))->getTableAsString();
 
         return implode(PHP_EOL, $message);
@@ -497,9 +601,9 @@ class TableEqualityAssertion
             $message[] = $content_message;
         }
 
-        $message[] = 'Expected order:';
+        $message[] = $this->getExpectedOrderLabel();
         $message[] = (new TableNode($expected_rows))->getTableAsString();
-        $message[] = 'Actual order:';
+        $message[] = $this->getActualOrderLabel();
         $message[] = (new TableNode($actual_rows))->getTableAsString();
 
         return implode(PHP_EOL, $message);

--- a/src/BehatTableComparison/TableEqualityAssertion.php
+++ b/src/BehatTableComparison/TableEqualityAssertion.php
@@ -15,8 +15,6 @@ class TableEqualityAssertion
 
     const DEFAULT_UNEXPECTED_ROWS_LABEL = 'Unexpected rows';
 
-    const UNSPECIFIED_DIFFERENCE_NOTICE = 'Notice: Detected differences that cannot yet be displayed. See https://github.com/TravisCarden/behat-table-comparison/issues/1.';
-
     /**
      * @var \Behat\Gherkin\Node\TableNode
      */
@@ -225,6 +223,14 @@ class TableEqualityAssertion
         $actual_body = implode(PHP_EOL, array_slice($combined_table_rows, count($expected_body_rows)));
 
         if ($expected_body != $actual_body) {
+            $sorted_expected_rows = $this->sortTable(new TableNode($expected_body_rows))->getRows();
+            $sorted_actual_rows = $this->sortTable(new TableNode($actual_body_rows))->getRows();
+
+            if ($sorted_expected_rows == $sorted_actual_rows) {
+                $message = $this->generateMessageForRowOrderMismatch($expected_body_rows, $actual_body_rows);
+                throw new UnequalTablesException($message);
+            }
+
             $diff = (new Differ("--- Expected\n+++ Actual\n"))
                 ->diff($expected_body, $actual_body);
             throw new UnequalTablesException($diff);
@@ -238,15 +244,6 @@ class TableEqualityAssertion
 
         if ($expected_body != $actual_body) {
             $message = $this->generateMessageForPostSortDifferences($expected_body->getRows(), $actual_body->getRows());
-
-            if (!$message) {
-                $message = implode(PHP_EOL, [
-                    self::UNSPECIFIED_DIFFERENCE_NOTICE,
-                    '*** Given',
-                    $actual_body->getTableAsString(),
-                ]);
-            }
-
             throw new UnequalTablesException($message);
         }
     }
@@ -284,25 +281,173 @@ class TableEqualityAssertion
     protected function generateMessageForPostSortDifferences(array $expected_rows, array $actual_rows)
     {
         $message = [];
-        $this->addArrayDiffMessageLines($message, $actual_rows, $expected_rows, '--- ' . $this->getMissingRowsLabel());
-        $this->addArrayDiffMessageLines($message, $expected_rows, $actual_rows, '+++ ' . $this->getUnexpectedRowsLabel());
+        $expected_counts = $this->countRows($expected_rows);
+        $actual_counts = $this->countRows($actual_rows);
+
+        // Rows completely absent from actual (expected > 0, actual == 0).
+        $missing_rows = $this->buildAbsentRows($expected_counts, $actual_counts);
+        // Rows entirely new in actual (actual > 0, expected == 0).
+        $unexpected_rows = $this->buildAbsentRows($actual_counts, $expected_counts);
+        // Rows present on both sides but with differing counts.
+        $duplicate_rows = $this->buildDuplicateRowDifferenceLines($expected_counts, $actual_counts);
+
+        if (!empty($missing_rows)) {
+            $message[] = '--- ' . $this->getMissingRowsLabel();
+            $message[] = (new TableNode($missing_rows))->getTableAsString();
+        }
+        if (!empty($unexpected_rows)) {
+            $message[] = '+++ ' . $this->getUnexpectedRowsLabel();
+            $message[] = (new TableNode($unexpected_rows))->getTableAsString();
+        }
+        if (!empty($duplicate_rows)) {
+            $message[] = '*** Duplicate rows';
+            foreach ($duplicate_rows as $line) {
+                $message[] = $line;
+            }
+        }
+
         return implode(PHP_EOL, $message);
     }
 
     /**
-     * @param array $message
-     * @param array $left
-     * @param array $right
-     * @param string $label
+     * @param array $rows
+     *
+     * @return array
      */
-    protected function addArrayDiffMessageLines(array &$message, array $left, array $right, $label)
+    protected function countRows(array $rows)
     {
-        $differences = array_filter($right, function (array $row) use ($left) {
-            return !in_array($row, $left);
-        });
-        if (!empty($differences)) {
-            $message[] = $label;
-            $message[] = (new TableNode($differences))->getTableAsString();
+        $counts = [];
+        foreach ($rows as $row) {
+            $key = json_encode($row);
+            if (!isset($counts[$key])) {
+                $counts[$key] = [
+                    'row' => $row,
+                    'count' => 0,
+                ];
+            }
+            $counts[$key]['count']++;
         }
+        return $counts;
+    }
+
+    /**
+     * Returns rows that appear in $present_counts but are completely absent from $absent_counts.
+     *
+     * @param array $present_counts
+     * @param array $absent_counts
+     *
+     * @return array
+     */
+    protected function buildAbsentRows(array $present_counts, array $absent_counts)
+    {
+        $rows = [];
+        foreach ($present_counts as $key => $data) {
+            if (!empty($absent_counts[$key]['count'])) {
+                continue;
+            }
+
+            for ($i = 0; $i < $data['count']; $i++) {
+                $rows[] = $data['row'];
+            }
+        }
+        return $rows;
+    }
+
+    /**
+     * @param array $expected_counts
+     * @param array $actual_counts
+     *
+     * @return array
+     */
+    protected function buildDuplicateRowDifferenceLines(array $expected_counts, array $actual_counts)
+    {
+        $lines = [];
+        $keys = array_unique(array_merge(array_keys($expected_counts), array_keys($actual_counts)));
+
+        foreach ($keys as $key) {
+            $expected_count = $expected_counts[$key]['count'] ?? 0;
+            $actual_count = $actual_counts[$key]['count'] ?? 0;
+            if ($expected_count == $actual_count) {
+                continue;
+            }
+            // Only report as duplicate when the row is present on both sides.
+            if ($expected_count === 0 || $actual_count === 0) {
+                continue;
+            }
+
+            $row = $actual_counts[$key]['row'] ?? $expected_counts[$key]['row'];
+            $row_string = (new TableNode([$row]))->getTableAsString();
+            $actual_times_label = $actual_count === 1 ? 'time' : 'times';
+            $lines[] = sprintf(
+                '%s (appears %d %s, expected %d)',
+                $row_string,
+                $actual_count,
+                $actual_times_label,
+                $expected_count
+            );
+        }
+
+        return $lines;
+    }
+
+    /**
+     * @param array $expected_rows
+     * @param array $actual_rows
+     *
+     * @return string
+     */
+    protected function generateMessageForRowOrderMismatch(array $expected_rows, array $actual_rows)
+    {
+        $message = ['*** Row order mismatch'];
+        $expected_positions = $this->mapRowPositions($expected_rows);
+        $actual_positions = $this->mapRowPositions($actual_rows);
+
+        foreach ($expected_positions as $key => $expected_data) {
+            $actual_data = $actual_positions[$key];
+            $position_count = min(count($expected_data['positions']), count($actual_data['positions']));
+
+            for ($i = 0; $i < $position_count; $i++) {
+                $expected_position = $expected_data['positions'][$i];
+                $actual_position = $actual_data['positions'][$i];
+                if ($expected_position == $actual_position) {
+                    continue;
+                }
+
+                $message[] = sprintf(
+                    '%s should be at position %d, found at %d',
+                    (new TableNode([$expected_data['row']]))->getTableAsString(),
+                    $expected_position,
+                    $actual_position
+                );
+            }
+        }
+
+        $message[] = 'Expected order:';
+        $message[] = (new TableNode($expected_rows))->getTableAsString();
+        $message[] = 'Actual order:';
+        $message[] = (new TableNode($actual_rows))->getTableAsString();
+
+        return implode(PHP_EOL, $message);
+    }
+
+    /**
+     * @param array $rows
+     *
+     * @return array
+     */
+    protected function mapRowPositions(array $rows)
+    {
+        $positions = [];
+        foreach ($rows as $index => $row) {
+            $key = json_encode($row);
+            if (!isset($positions[$key])) {
+                $positions[$key] = [
+                    'row' => $row,
+                    'positions' => [],
+                ];
+            }
+            $positions[$key]['positions'][] = $index + 1;
+        }
+        return $positions;
     }
 }

--- a/tests/BehatTableComparison/TableEqualityAssertionTest.php
+++ b/tests/BehatTableComparison/TableEqualityAssertionTest.php
@@ -72,6 +72,10 @@ class TableEqualityAssertionTest extends TestCase
         self::assertSame(TableEqualityAssertion::DEFAULT_UNEXPECTED_ROWS_LABEL, $assertion->getUnexpectedRowsLabel());
         self::assertSame(TableEqualityAssertion::DEFAULT_DUPLICATE_ROWS_LABEL, $assertion->getDuplicateRowsLabel());
         self::assertSame(TableEqualityAssertion::DEFAULT_ROW_ORDER_MISMATCH_LABEL, $assertion->getRowOrderMismatchLabel());
+        self::assertSame(TableEqualityAssertion::DEFAULT_EXPECTED_HEADER_LABEL, $assertion->getExpectedHeaderLabel());
+        self::assertSame(TableEqualityAssertion::DEFAULT_GIVEN_HEADER_LABEL, $assertion->getGivenHeaderLabel());
+        self::assertSame(TableEqualityAssertion::DEFAULT_EXPECTED_ORDER_LABEL, $assertion->getExpectedOrderLabel());
+        self::assertSame(TableEqualityAssertion::DEFAULT_ACTUAL_ORDER_LABEL, $assertion->getActualOrderLabel());
 
         // Set values.
         $assertion
@@ -80,13 +84,21 @@ class TableEqualityAssertionTest extends TestCase
             ->setMissingRowsLabel('Gone')
             ->setUnexpectedRowsLabel('Extra')
             ->setDuplicateRowsLabel('Cloned')
-            ->setRowOrderMismatchLabel('Scrambled');
+            ->setRowOrderMismatchLabel('Scrambled')
+            ->setExpectedHeaderLabel('Expected columns')
+            ->setGivenHeaderLabel('Actual columns')
+            ->setExpectedOrderLabel('Expected sequence')
+            ->setActualOrderLabel('Actual sequence');
         self::assertFalse($assertion->isRowOrderRespected());
         self::assertEquals([1, 2, 3], $assertion->getExpectedHeader());
         self::assertSame('Gone', $assertion->getMissingRowsLabel());
         self::assertSame('Extra', $assertion->getUnexpectedRowsLabel());
         self::assertSame('Cloned', $assertion->getDuplicateRowsLabel());
         self::assertSame('Scrambled', $assertion->getRowOrderMismatchLabel());
+        self::assertSame('Expected columns', $assertion->getExpectedHeaderLabel());
+        self::assertSame('Actual columns', $assertion->getGivenHeaderLabel());
+        self::assertSame('Expected sequence', $assertion->getExpectedOrderLabel());
+        self::assertSame('Actual sequence', $assertion->getActualOrderLabel());
 
         // Unset values.
         $assertion
@@ -354,11 +366,11 @@ class TableEqualityAssertionTest extends TestCase
                 '*** Row order mismatch',
                 '| id1 | Label one | should be at position 1, found at 2',
                 '| id2 | Label two | should be at position 2, found at 1',
-                'Expected order:',
+                'Expected order',
                 '| id1 | Label one   |',
                 '| id2 | Label two   |',
                 '| id3 | Label three |',
-                'Actual order:',
+                'Actual order',
                 '| id2 | Label two   |',
                 '| id1 | Label one   |',
                 '| id3 | Label three |',
@@ -432,6 +444,50 @@ class TableEqualityAssertionTest extends TestCase
     }
 
     /**
+     * Tests assertion with custom header labels.
+     */
+    public function testAssertionWithCustomHeaderLabels()
+    {
+        $this->expectException(\LogicException::class);
+        $rows = [['Label one', 'id1'], ['Label two', 'id2']];
+        $left = $right = new TableNode($rows);
+
+        try {
+            (new TableEqualityAssertion($left, $right))
+                ->expectHeader(['label', 'id'])
+                ->setExpectedHeaderLabel('Expected columns')
+                ->setGivenHeaderLabel('Actual columns')
+                ->assert();
+        } catch (\LogicException $e) {
+            self::assertStringContainsString('--- Expected columns', $e->getMessage());
+            self::assertStringContainsString('+++ Actual columns', $e->getMessage());
+            throw $e;
+        }
+    }
+
+    /**
+     * Tests assertion with custom order labels.
+     */
+    public function testAssertionWithCustomOrderLabels()
+    {
+        $this->expectException(UnequalTablesException::class);
+        $assertion = (new TableEqualityAssertion(
+            new TableNode([[1], [2]]),
+            new TableNode([[2], [1]])
+        ))
+            ->setExpectedOrderLabel('Expected sequence')
+            ->setActualOrderLabel('Actual sequence');
+
+        try {
+            $assertion->assert();
+        } catch (UnequalTablesException $e) {
+            self::assertStringContainsString('Expected sequence', $e->getMessage());
+            self::assertStringContainsString('Actual sequence', $e->getMessage());
+            throw $e;
+        }
+    }
+
+    /**
      * Tests assertion with a table header.
      */
     public function testAssertionWithHeader()
@@ -465,7 +521,7 @@ class TableEqualityAssertionTest extends TestCase
             $expected = implode(PHP_EOL, [
                 '--- Expected header',
                 '| label | id |',
-                '+++ Given',
+                '+++ Given header',
                 '| Label one | id1 |',
             ]);
             self::assertSame($expected, $e->getMessage());
@@ -526,10 +582,10 @@ class TableEqualityAssertionTest extends TestCase
                     '| id1 | alpha |',
                     '+++ Unexpected rows',
                     '| id1 | CHANGED |',
-                    'Expected order:',
+                    'Expected order',
                     '| id1 | alpha |',
                     '| id2 | beta  |',
-                    'Actual order:',
+                    'Actual order',
                     '| id1 | CHANGED |',
                     '| id2 | beta    |',
                 ],
@@ -554,12 +610,12 @@ class TableEqualityAssertionTest extends TestCase
                     '+++ Unexpected rows',
                     '| id1 | CHANGED |',
                     '| id5 | epsilon |',
-                    'Expected order:',
+                    'Expected order',
                     '| id1 | alpha |',
                     '| id2 | beta  |',
                     '| id3 | gamma |',
                     '| id4 | delta |',
-                    'Actual order:',
+                    'Actual order',
                     '| id3 | gamma   |',
                     '| id1 | CHANGED |',
                     '| id4 | delta   |',
@@ -615,7 +671,7 @@ class TableEqualityAssertionTest extends TestCase
                 '| 13 | thirteen |',
                 '*** Duplicate rows',
                 '| 2 | two | (appears 2 times, expected 1)',
-                'Expected order:',
+                'Expected order',
                 '| 1  | one   |',
                 '| 2  | two   |',
                 '| 3  | three |',
@@ -626,7 +682,7 @@ class TableEqualityAssertionTest extends TestCase
                 '| 8  | eight |',
                 '| 9  | nine  |',
                 '| 10 | ten   |',
-                'Actual order:',
+                'Actual order',
                 '| 1  | one      |',
                 '| 2  | two      |',
                 '| 2  | two      |',

--- a/tests/BehatTableComparison/TableEqualityAssertionTest.php
+++ b/tests/BehatTableComparison/TableEqualityAssertionTest.php
@@ -489,7 +489,88 @@ class TableEqualityAssertionTest extends TestCase
     }
 
     /**
-     * Tests assertion with complex differences.
+     * Tests assertion with content differences while respecting row order.
+     *
+     * @dataProvider providerTestAssertionWithContentDifferencesRespectingRowOrder
+     */
+    public function testAssertionWithContentDifferencesRespectingRowOrder($left, $right, $expected)
+    {
+        $this->expectException(UnequalTablesException::class);
+        $left = new TableNode($left);
+        $right = new TableNode($right);
+
+        try {
+            (new TableEqualityAssertion($left, $right))
+                ->assert();
+        } catch (UnequalTablesException $e) {
+            $expected = implode(PHP_EOL, $expected);
+            self::assertSame($expected, $e->getMessage());
+            throw $e;
+        }
+    }
+
+    public function providerTestAssertionWithContentDifferencesRespectingRowOrder()
+    {
+        return [
+            'Content differences, same order' => [
+                [
+                    ['id1', 'alpha'],
+                    ['id2', 'beta'],
+                ],
+                [
+                    ['id1', 'CHANGED'],
+                    ['id2', 'beta'],
+                ],
+                [
+                    '--- Missing rows',
+                    '| id1 | alpha |',
+                    '+++ Unexpected rows',
+                    '| id1 | CHANGED |',
+                    'Expected order:',
+                    '| id1 | alpha |',
+                    '| id2 | beta  |',
+                    'Actual order:',
+                    '| id1 | CHANGED |',
+                    '| id2 | beta    |',
+                ],
+            ],
+            'Content differences and row order both differ' => [
+                [
+                    ['id1', 'alpha'],
+                    ['id2', 'beta'],
+                    ['id3', 'gamma'],
+                    ['id4', 'delta'],
+                ],
+                [
+                    ['id3', 'gamma'],
+                    ['id1', 'CHANGED'],
+                    ['id4', 'delta'],
+                    ['id5', 'epsilon'],
+                ],
+                [
+                    '--- Missing rows',
+                    '| id1 | alpha |',
+                    '| id2 | beta  |',
+                    '+++ Unexpected rows',
+                    '| id1 | CHANGED |',
+                    '| id5 | epsilon |',
+                    'Expected order:',
+                    '| id1 | alpha |',
+                    '| id2 | beta  |',
+                    '| id3 | gamma |',
+                    '| id4 | delta |',
+                    'Actual order:',
+                    '| id3 | gamma   |',
+                    '| id1 | CHANGED |',
+                    '| id4 | delta   |',
+                    '| id5 | epsilon |',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Tests assertion with complex differences respecting row order.
      */
     public function testAssertionWithComplexDifferences()
     {
@@ -526,24 +607,37 @@ class TableEqualityAssertionTest extends TestCase
                 ->assert();
         } catch (UnequalTablesException $e) {
             $expected = implode(PHP_EOL, [
-                '--- Expected',
-                '+++ Actual',
-                '@@ @@',
-                ' | 1  | one      |',
-                ' | 2  | two      |',
-                '+| 2  | two      |',
-                ' | 3  | three    |',
-                ' | 4  | four     |',
-                '-| 5  | five     |',
-                ' | 6  | six      |',
-                ' | 7  | seven    |',
-                '-| 8  | eight    |',
-                '+| 8  | changed  |',
-                ' | 9  | nine     |',
-                '-| 10 | ten      |', // These two lines seem unintuitive, but
-                '+| 10 | ten      |', // they come straight from the differ.
-                '+| 13 | thirteen |',
-                '',
+                '--- Missing rows',
+                '| 5 | five  |',
+                '| 8 | eight |',
+                '+++ Unexpected rows',
+                '| 8  | changed  |',
+                '| 13 | thirteen |',
+                '*** Duplicate rows',
+                '| 2 | two | (appears 2 times, expected 1)',
+                'Expected order:',
+                '| 1  | one   |',
+                '| 2  | two   |',
+                '| 3  | three |',
+                '| 4  | four  |',
+                '| 5  | five  |',
+                '| 6  | six   |',
+                '| 7  | seven |',
+                '| 8  | eight |',
+                '| 9  | nine  |',
+                '| 10 | ten   |',
+                'Actual order:',
+                '| 1  | one      |',
+                '| 2  | two      |',
+                '| 2  | two      |',
+                '| 3  | three    |',
+                '| 4  | four     |',
+                '| 6  | six      |',
+                '| 7  | seven    |',
+                '| 8  | changed  |',
+                '| 9  | nine     |',
+                '| 10 | ten      |',
+                '| 13 | thirteen |',
             ]);
             self::assertSame($expected, $e->getMessage());
 

--- a/tests/BehatTableComparison/TableEqualityAssertionTest.php
+++ b/tests/BehatTableComparison/TableEqualityAssertionTest.php
@@ -68,13 +68,25 @@ class TableEqualityAssertionTest extends TestCase
         $assertion = (new TableEqualityAssertion($this->arbitraryLeft, $this->arbitraryRight));
         self::assertTrue($assertion->isRowOrderRespected());
         self::assertEmpty($assertion->getExpectedHeader());
+        self::assertSame(TableEqualityAssertion::DEFAULT_MISSING_ROWS_LABEL, $assertion->getMissingRowsLabel());
+        self::assertSame(TableEqualityAssertion::DEFAULT_UNEXPECTED_ROWS_LABEL, $assertion->getUnexpectedRowsLabel());
+        self::assertSame(TableEqualityAssertion::DEFAULT_DUPLICATE_ROWS_LABEL, $assertion->getDuplicateRowsLabel());
+        self::assertSame(TableEqualityAssertion::DEFAULT_ROW_ORDER_MISMATCH_LABEL, $assertion->getRowOrderMismatchLabel());
 
         // Set values.
         $assertion
             ->ignoreRowOrder()
-            ->expectHeader([1, 2, 3]);
+            ->expectHeader([1, 2, 3])
+            ->setMissingRowsLabel('Gone')
+            ->setUnexpectedRowsLabel('Extra')
+            ->setDuplicateRowsLabel('Cloned')
+            ->setRowOrderMismatchLabel('Scrambled');
         self::assertFalse($assertion->isRowOrderRespected());
         self::assertEquals([1, 2, 3], $assertion->getExpectedHeader());
+        self::assertSame('Gone', $assertion->getMissingRowsLabel());
+        self::assertSame('Extra', $assertion->getUnexpectedRowsLabel());
+        self::assertSame('Cloned', $assertion->getDuplicateRowsLabel());
+        self::assertSame('Scrambled', $assertion->getRowOrderMismatchLabel());
 
         // Unset values.
         $assertion
@@ -391,7 +403,32 @@ class TableEqualityAssertionTest extends TestCase
                 'Free rows!',
                 '+++',
             ],
+            'Duplicate rows' => [
+                'setDuplicateRowsLabel',
+                [new TableNode([[1], [2]]), new TableNode([[1], [2], [2]])],
+                'Cloned rows!',
+                '***',
+            ],
         ];
+    }
+
+    /**
+     * Tests assertion with a custom row order mismatch label.
+     */
+    public function testAssertionWithCustomRowOrderMismatchLabel()
+    {
+        $this->expectException(UnequalTablesException::class);
+        $assertion = (new TableEqualityAssertion(
+            new TableNode([[1], [2]]),
+            new TableNode([[2], [1]])
+        ))->setRowOrderMismatchLabel('Wrong order!');
+
+        try {
+            $assertion->assert();
+        } catch (UnequalTablesException $e) {
+            self::assertStringStartsWith('*** Wrong order!', $e->getMessage());
+            throw $e;
+        }
     }
 
     /**

--- a/tests/BehatTableComparison/TableEqualityAssertionTest.php
+++ b/tests/BehatTableComparison/TableEqualityAssertionTest.php
@@ -193,14 +193,11 @@ class TableEqualityAssertionTest extends TestCase
     }
 
     /**
-     * Tests assertion with tables that are unequal in ways that do not yet have error messages specified.
+     * Tests assertion with complex differences while ignoring row order.
      *
-     * @todo Specify these scenarios.
-     * @see https://github.com/TravisCarden/behat-table-comparison/issues/1
-     *
-     * @dataProvider providerTestAssertionWithUnspecifiedInequalities
+     * @dataProvider providerTestAssertionWithComplexDifferencesIgnoringRowOrder
      */
-    public function testAssertionWithUnspecifiedInequalities($left, $right)
+    public function testAssertionWithComplexDifferencesIgnoringRowOrder($left, $right, $expected)
     {
         $this->expectException(UnequalTablesException::class);
         $left = new TableNode($left);
@@ -211,15 +208,16 @@ class TableEqualityAssertionTest extends TestCase
                 ->ignoreRowOrder()
                 ->assert();
         } catch (UnequalTablesException $e) {
-            $this->assertUnspecifiedErrorException($e, $right);
+            $expected = implode(PHP_EOL, $expected);
+            self::assertSame($expected, $e->getMessage());
             throw $e;
         }
     }
 
-    public function providerTestAssertionWithUnspecifiedInequalities()
+    public function providerTestAssertionWithComplexDifferencesIgnoringRowOrder()
     {
         return [
-            'Duplicate rows on right' => [
+            'Duplicate rows on actual' => [
                 [
                     ['id1', 'Label one'],
                     ['id2', 'Label two'],
@@ -228,22 +226,134 @@ class TableEqualityAssertionTest extends TestCase
                     ['id1', 'Label one'],
                     ['id2', 'Label two'],
                     ['id2', 'Label two'],
-                    ['id2', 'Label two'],
+                ],
+                [
+                    '*** Duplicate rows',
+                    '| id2 | Label two | (appears 2 times, expected 1)',
                 ],
             ],
-            'Duplicate rows on left' => [
+            'Duplicate rows on expected' => [
                 [
                     ['id1', 'Label one'],
-                    ['id2', 'Label two'],
                     ['id2', 'Label two'],
                     ['id2', 'Label two'],
                 ],
                 [
                     ['id1', 'Label one'],
                     ['id2', 'Label two'],
+                ],
+                [
+                    '*** Duplicate rows',
+                    '| id2 | Label two | (appears 1 time, expected 2)',
+                ],
+            ],
+            'Duplicate rows fully missing from actual' => [
+                [
+                    ['id1', 'Label one'],
+                    ['id2', 'Label two'],
+                    ['id2', 'Label two'],
+                ],
+                [
+                    ['id1', 'Label one'],
+                ],
+                [
+                    '--- Missing rows',
+                    '| id2 | Label two |',
+                    '| id2 | Label two |',
+                ],
+            ],
+            'Duplicate rows fully unexpected in actual' => [
+                [
+                    ['id1', 'Label one'],
+                ],
+                [
+                    ['id1', 'Label one'],
+                    ['id2', 'Label two'],
+                    ['id2', 'Label two'],
+                ],
+                [
+                    '+++ Unexpected rows',
+                    '| id2 | Label two |',
+                    '| id2 | Label two |',
+                ],
+            ],
+            'Missing, unexpected, and duplicate rows together' => [
+                [
+                    ['id1', 'Label one'],
+                    ['id2', 'Label two'],
+                    ['id3', 'Label three'],
+                ],
+                [
+                    ['id1', 'Label one'],
+                    ['id2', 'Label two'],
+                    ['id2', 'Label two'],
+                    ['id4', 'Label four'],
+                ],
+                [
+                    '--- Missing rows',
+                    '| id3 | Label three |',
+                    '+++ Unexpected rows',
+                    '| id4 | Label four |',
+                    '*** Duplicate rows',
+                    '| id2 | Label two | (appears 2 times, expected 1)',
+                ],
+            ],
+            'Changed row becomes missing and unexpected' => [
+                [
+                    ['id1', 'same'],
+                    ['id2', 'before'],
+                ],
+                [
+                    ['id1', 'same'],
+                    ['id2', 'after'],
+                ],
+                [
+                    '--- Missing rows',
+                    '| id2 | before |',
+                    '+++ Unexpected rows',
+                    '| id2 | after |',
                 ],
             ],
         ];
+    }
+
+    /**
+     * Tests row order mismatch display while respecting row order.
+     */
+    public function testAssertionWithRowOrderMismatchMessage()
+    {
+        $this->expectException(UnequalTablesException::class);
+        $left = new TableNode([
+            ['id1', 'Label one'],
+            ['id2', 'Label two'],
+            ['id3', 'Label three'],
+        ]);
+        $right = new TableNode([
+            ['id2', 'Label two'],
+            ['id1', 'Label one'],
+            ['id3', 'Label three'],
+        ]);
+
+        try {
+            (new TableEqualityAssertion($left, $right))
+                ->assert();
+        } catch (UnequalTablesException $e) {
+            $expected = implode(PHP_EOL, [
+                '*** Row order mismatch',
+                '| id1 | Label one | should be at position 1, found at 2',
+                '| id2 | Label two | should be at position 2, found at 1',
+                'Expected order:',
+                '| id1 | Label one   |',
+                '| id2 | Label two   |',
+                '| id3 | Label three |',
+                'Actual order:',
+                '| id2 | Label two   |',
+                '| id1 | Label one   |',
+                '| id3 | Label three |',
+            ]);
+            self::assertSame($expected, $e->getMessage());
+            throw $e;
+        }
     }
 
     /**
@@ -402,19 +512,5 @@ class TableEqualityAssertionTest extends TestCase
 
             throw $e;
         }
-    }
-
-    /**
-     * @param \Exception $e
-     * @param TableNode $right
-     */
-    protected function assertUnspecifiedErrorException(\Exception $e, TableNode $right)
-    {
-        $message = implode(PHP_EOL, [
-            TableEqualityAssertion::UNSPECIFIED_DIFFERENCE_NOTICE,
-            '*** Given',
-            $right->getTableAsString(),
-        ]);
-        self::assertSame($message, $e->getMessage());
     }
 }


### PR DESCRIPTION
## Summary

This PR completes the specification requested in #1 and implements it end to end.

It defines and tests error message behavior for complex table differences, including:
- Missing rows
- Unexpected rows
- Duplicate row multiplicity mismatches
- Row-order mismatch diagnostics
- Content differences while respecting row order
- Header mismatch diagnostics

It also documents the behavior in [README.md](README.md) under "Error Message Specification".

## What Changed

- Implemented semantic complex-difference message generation (no unspecified fallback path).
- Replaced confusing raw diff output in content+order scenarios with actionable sectioned output.
- Added/expanded configurable labels for all user-facing sections and subheadings.
- Normalized label wording for consistency (including header and order labels).
- Added comprehensive PHPUnit coverage for all specified scenarios and custom-label behavior.
- Updated README usage and specification documentation.

## Issue

Closes #1