### PR TITLE
Eliminate implicit dependency on `behat/behat`

### DIFF
--- a/src/BehatTableComparison/UnequalTablesException.php
+++ b/src/BehatTableComparison/UnequalTablesException.php
@@ -2,11 +2,9 @@
 
 namespace TravisCarden\BehatTableComparison;
 
-use Behat\Testwork\Tester\Exception\TesterException;
-
 /**
  * An exception for table inequalities.
  */
-class UnequalTablesException extends \RuntimeException implements TesterException
+class UnequalTablesException extends \RuntimeException
 {
 }

--- a/tests/BehatTableComparison/UnequalTablesExceptionTest.php
+++ b/tests/BehatTableComparison/UnequalTablesExceptionTest.php
@@ -2,7 +2,6 @@
 
 namespace TravisCarden\Tests\BehatTableComparison;
 
-use Behat\Testwork\Tester\Exception\TesterException;
 use PHPUnit\Framework\TestCase;
 use TravisCarden\BehatTableComparison\UnequalTablesException;
 
@@ -19,7 +18,6 @@ class UnequalTablesExceptionTest extends TestCase
     {
         $exception = new UnequalTablesException();
 
-        $this->assertInstanceOf(TesterException::class, $exception);
         $this->assertInstanceOf(\RuntimeException::class, $exception);
     }
 }


### PR DESCRIPTION
There is currently a needless, implicit dependency on an exception in `behat/behat`. This removes it so the library doesn't technically even depend on Behat itself--the chief benefit of which is no dependency graph sensitivity, i.e., Behat can change and release no versions all it wants and this library won't have to change.