### PR TITLE
Unify assertion failures under `UnequalTablesException` with stable error codes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -63,7 +63,30 @@ Output is like the following:
 
 ## Error Message Specification
 
-When tables are unequal, the assertion throws a detailed error message with labeled sections.
+When tables are unequal, the assertion throws `UnequalTablesException` with a detailed
+diagnostic message. The integer error code, available via `getCode()`, identifies the
+category of failure:
+
+| Constant                                     | When thrown                                                            |
+|----------------------------------------------|------------------------------------------------------------------------|
+| `UnequalTablesException::HEADER_MISMATCH`    | The header row does not match the expected header.                     |
+| `UnequalTablesException::CONTENT_MISMATCH`   | Rows are missing, unexpected, or duplicated.                           |
+| `UnequalTablesException::ROW_ORDER_MISMATCH` | The same rows are present but in a different order.                    |
+| `UnequalTablesException::STRUCTURAL_ERROR`   | A structural failure occurred processing a table; see `getPrevious()`. |
+
+Consumers should use the named constants rather than bare integers. For example:
+
+```php
+try {
+    (new TableEqualityAssertion($expected, $actual))->assert();
+} catch (UnequalTablesException $e) {
+    match ($e->getCode()) {
+        UnequalTablesException::HEADER_MISMATCH    => /* handle header issue */,
+        UnequalTablesException::ROW_ORDER_MISMATCH => /* handle order issue */,
+        default                                    => /* handle content issue */,
+    };
+}
+```
 
 For a complete list of stable/public guarantees, see [Contract Surface](contract-surface.md).
 

--- a/docs/contract-surface.md
+++ b/docs/contract-surface.md
@@ -19,15 +19,24 @@ The following are part of the public contract for `1.x`:
 - Constructor and public methods on `TableEqualityAssertion`.
 - Fluent setter behavior on `TableEqualityAssertion` (setters return `$this`).
 - Public constants on `TableEqualityAssertion` representing default labels.
+- Public constants on `UnequalTablesException` representing error codes.
 
 Any change to the above is at least `behavior-changing` and may be `breaking`.
 
 ## Exception Contract
 
-- Content/body inequality failures throw `UnequalTablesException`.
-- Header expectation failures currently throw `LogicException`.
+All assertion failures from `assert()` throw `UnequalTablesException`. The integer error code,
+available via `getCode()`, identifies the category of failure:
 
-This split is currently part of observed behavior and must be treated as contract unless intentionally changed and documented as `breaking`.
+| Constant                                     | Value | When thrown                                                                                                     |
+|----------------------------------------------|-------|-----------------------------------------------------------------------------------------------------------------|
+| `UnequalTablesException::HEADER_MISMATCH`    | `1`   | The header row does not match the expected header.                                                              |
+| `UnequalTablesException::CONTENT_MISMATCH`   | `2`   | Rows are missing, unexpected, or duplicated.                                                                    |
+| `UnequalTablesException::ROW_ORDER_MISMATCH` | `3`   | The same rows are present but in a different order.                                                             |
+| `UnequalTablesException::STRUCTURAL_ERROR`   | `4`   | A structural failure occurred processing a table node; the original exception is available via `getPrevious()`. |
+
+The constant names, integer values, and the single-exception-type guarantee are stable contract in `1.x`.
+Consumers should use the constants (not bare integers) for clarity and forward-compatibility.
 
 ## Diagnostics Contract
 
@@ -92,8 +101,9 @@ Use this checklist for release candidates and release PRs.
   - public classes/methods/signatures/constants unchanged, or changes are documented.
   - fluent setter methods still return `$this`.
 - Exception behavior audit completed:
-  - content/body mismatch still throws `UnequalTablesException`.
-  - header mismatch behavior is unchanged or intentionally migrated with notes.
+  - all assertion failures throw `UnequalTablesException` (no low-level exceptions leak).
+  - error code constants (`HEADER_MISMATCH`, `CONTENT_MISMATCH`, `ROW_ORDER_MISMATCH`, `STRUCTURAL_ERROR`) are assigned correctly.
+  - `STRUCTURAL_ERROR` wraps original exception via `getPrevious()`.
 - Diagnostics audit completed:
   - section labels/semantics/order reviewed against README and integration expectations.
   - duplicate count annotation semantics preserved.

--- a/src/TableEqualityAssertion.php
+++ b/src/TableEqualityAssertion.php
@@ -2,8 +2,9 @@
 
 namespace TravisCarden\BehatTableComparison;
 
+use Behat\Gherkin\Exception\NodeException;
 use Behat\Gherkin\Node\TableNode;
-use LogicException;
+use JsonException;
 
 /**
  * Asserts equality between two TableNodes.
@@ -201,20 +202,25 @@ final class TableEqualityAssertion
      * Performs the assertion.
      *
      * @throws \TravisCarden\BehatTableComparison\UnequalTablesException
-     * @throws \LogicException
-     * @throws \Behat\Gherkin\Exception\NodeException
-     * @throws \JsonException
      */
     public function assert(): bool
     {
-        $this->assertHeader();
-        $this->assertBody();
+        try {
+            $this->assertHeader();
+            $this->assertBody();
+        } catch (NodeException|JsonException $e) {
+            throw new UnequalTablesException(
+                $e->getMessage(),
+                UnequalTablesException::STRUCTURAL_ERROR,
+                $e,
+            );
+        }
 
         return true;
     }
 
     /**
-     * @throws \LogicException
+     * @throws \TravisCarden\BehatTableComparison\UnequalTablesException
      * @throws \Behat\Gherkin\Exception\NodeException
      */
     private function assertHeader(): void
@@ -238,7 +244,7 @@ final class TableEqualityAssertion
             (new TableNode([$actualHeader]))->getTableAsString(),
         ];
 
-        throw new LogicException(implode(PHP_EOL, $message));
+        throw new UnequalTablesException(implode(PHP_EOL, $message), UnequalTablesException::HEADER_MISMATCH);
     }
 
     /**
@@ -280,12 +286,12 @@ final class TableEqualityAssertion
             if ($sortedExpectedRows === $sortedActualRows) {
                 $message = $this->generateMessageForRowOrderMismatch($expectedBodyRows, $actualBodyRows);
 
-                throw new UnequalTablesException($message);
+                throw new UnequalTablesException($message, UnequalTablesException::ROW_ORDER_MISMATCH);
             }
 
             $message = $this->generateMessageForContentAndOrderDifferences($expectedBodyRows, $actualBodyRows);
 
-            throw new UnequalTablesException($message);
+            throw new UnequalTablesException($message, UnequalTablesException::CONTENT_MISMATCH);
         }
     }
 
@@ -302,7 +308,7 @@ final class TableEqualityAssertion
         if ($expectedBody->getRows() !== $actualBody->getRows()) {
             $message = $this->generateMessageForPostSortDifferences($expectedBody->getRows(), $actualBody->getRows());
 
-            throw new UnequalTablesException($message);
+            throw new UnequalTablesException($message, UnequalTablesException::CONTENT_MISMATCH);
         }
     }
 

--- a/src/UnequalTablesException.php
+++ b/src/UnequalTablesException.php
@@ -9,4 +9,25 @@ use RuntimeException;
  */
 final class UnequalTablesException extends RuntimeException
 {
+    /**
+     * The header row of the given table did not match the assertion's expected header.
+     */
+    public const int HEADER_MISMATCH = 1;
+
+    /**
+     * The tables differ in content: one or more rows are missing, unexpected, or duplicated.
+     */
+    public const int CONTENT_MISMATCH = 2;
+
+    /**
+     * The tables contain the same rows but in a different order.
+     */
+    public const int ROW_ORDER_MISMATCH = 3;
+
+    /**
+     * A structural error occurred while processing a table (e.g., invalid table node).
+     *
+     * The original low-level exception is available via getPrevious().
+     */
+    public const int STRUCTURAL_ERROR = 4;
 }

--- a/tests/unit/TableEqualityAssertionTest.php
+++ b/tests/unit/TableEqualityAssertionTest.php
@@ -3,7 +3,6 @@
 namespace TravisCarden\BehatTableComparison\Tests\Unit;
 
 use Behat\Gherkin\Node\TableNode;
-use LogicException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -108,6 +107,7 @@ final class TableEqualityAssertionTest extends TestCase
         } catch (UnequalTablesException $e) {
             $expected = implode(PHP_EOL, $expected);
             self::assertSame($expected, $e->getMessage());
+            self::assertSame(UnequalTablesException::CONTENT_MISMATCH, $e->getCode());
 
             throw $e;
         }
@@ -133,6 +133,7 @@ final class TableEqualityAssertionTest extends TestCase
         } catch (UnequalTablesException $e) {
             $expected = implode(PHP_EOL, $expected);
             self::assertSame($expected, $e->getMessage());
+            self::assertSame(UnequalTablesException::CONTENT_MISMATCH, $e->getCode());
 
             throw $e;
         }
@@ -173,6 +174,7 @@ final class TableEqualityAssertionTest extends TestCase
                 '| id3 | Label three |',
             ]);
             self::assertSame($expected, $e->getMessage());
+            self::assertSame(UnequalTablesException::ROW_ORDER_MISMATCH, $e->getCode());
 
             throw $e;
         }
@@ -192,6 +194,7 @@ final class TableEqualityAssertionTest extends TestCase
             $assertion->assert();
         } catch (UnequalTablesException $e) {
             self::assertStringStartsWith("{$prefix} {$label}", $e->getMessage());
+            self::assertSame(UnequalTablesException::CONTENT_MISMATCH, $e->getCode());
 
             throw $e;
         }
@@ -212,6 +215,7 @@ final class TableEqualityAssertionTest extends TestCase
             $assertion->assert();
         } catch (UnequalTablesException $e) {
             self::assertStringStartsWith('*** Wrong order!', $e->getMessage());
+            self::assertSame(UnequalTablesException::ROW_ORDER_MISMATCH, $e->getCode());
 
             throw $e;
         }
@@ -222,7 +226,7 @@ final class TableEqualityAssertionTest extends TestCase
      */
     public function testAssertionWithCustomHeaderLabels(): void
     {
-        $this->expectException(LogicException::class);
+        $this->expectException(UnequalTablesException::class);
         $rows = [['Label one', 'id1'], ['Label two', 'id2']];
         $left = new TableNode($rows);
         $right = $left;
@@ -233,9 +237,10 @@ final class TableEqualityAssertionTest extends TestCase
                 ->setExpectedHeaderLabel('Expected columns')
                 ->setGivenHeaderLabel('Actual columns')
                 ->assert();
-        } catch (LogicException $e) {
+        } catch (UnequalTablesException $e) {
             self::assertStringContainsString('--- Expected columns', $e->getMessage());
             self::assertStringContainsString('+++ Actual columns', $e->getMessage());
+            self::assertSame(UnequalTablesException::HEADER_MISMATCH, $e->getCode());
 
             throw $e;
         }
@@ -259,6 +264,7 @@ final class TableEqualityAssertionTest extends TestCase
         } catch (UnequalTablesException $e) {
             self::assertStringContainsString('Expected sequence', $e->getMessage());
             self::assertStringContainsString('Actual sequence', $e->getMessage());
+            self::assertSame(UnequalTablesException::ROW_ORDER_MISMATCH, $e->getCode());
 
             throw $e;
         }
@@ -286,7 +292,7 @@ final class TableEqualityAssertionTest extends TestCase
      */
     public function testAssertionWithHeaderMismatch(): void
     {
-        $this->expectException(LogicException::class);
+        $this->expectException(UnequalTablesException::class);
         $rows = [['Label one', 'id1'], ['Label two', 'id2']];
         $left = new TableNode($rows);
         $right = $left;
@@ -295,7 +301,7 @@ final class TableEqualityAssertionTest extends TestCase
             (new TableEqualityAssertion($left, $right))
                 ->expectHeader(['label', 'id'])
                 ->assert();
-        } catch (LogicException $e) {
+        } catch (UnequalTablesException $e) {
             $expected = implode(PHP_EOL, [
                 '--- Expected header',
                 '| label | id |',
@@ -303,6 +309,7 @@ final class TableEqualityAssertionTest extends TestCase
                 '| Label one | id1 |',
             ]);
             self::assertSame($expected, $e->getMessage());
+            self::assertSame(UnequalTablesException::HEADER_MISMATCH, $e->getCode());
 
             throw $e;
         }
@@ -354,6 +361,7 @@ final class TableEqualityAssertionTest extends TestCase
         } catch (UnequalTablesException $e) {
             $expected = implode(PHP_EOL, $expected);
             self::assertSame($expected, $e->getMessage());
+            self::assertSame(UnequalTablesException::CONTENT_MISMATCH, $e->getCode());
 
             throw $e;
         }
@@ -430,6 +438,7 @@ final class TableEqualityAssertionTest extends TestCase
                 '| 13 | thirteen |',
             ]);
             self::assertSame($expected, $e->getMessage());
+            self::assertSame(UnequalTablesException::CONTENT_MISMATCH, $e->getCode());
 
             throw $e;
         }

--- a/tests/unit/UnequalTablesExceptionTest.php
+++ b/tests/unit/UnequalTablesExceptionTest.php
@@ -2,6 +2,8 @@
 
 namespace TravisCarden\BehatTableComparison\Tests\Unit;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use TravisCarden\BehatTableComparison\UnequalTablesException;
@@ -9,15 +11,73 @@ use TravisCarden\BehatTableComparison\UnequalTablesException;
 /**
  * Provides unit tests for UnequalTablesException.
  */
+#[CoversClass(UnequalTablesException::class)]
 final class UnequalTablesExceptionTest extends TestCase
 {
-  /**
-   * Tests class inheritance.
-   */
+    /**
+     * Tests class inheritance.
+     */
     public function testInheritance(): void
     {
         $exception = new UnequalTablesException();
 
         $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    /**
+     * Tests that all error code constants are defined, are integers, and are distinct.
+     */
+    public function testErrorCodeConstantsAreDefinedAndDistinct(): void
+    {
+        $codes = [
+            UnequalTablesException::HEADER_MISMATCH,
+            UnequalTablesException::CONTENT_MISMATCH,
+            UnequalTablesException::ROW_ORDER_MISMATCH,
+            UnequalTablesException::STRUCTURAL_ERROR,
+        ];
+
+        foreach ($codes as $code) {
+            self::assertIsInt($code);
+        }
+
+        self::assertSame($codes, array_unique($codes), 'All error code constants must be distinct.');
+    }
+
+    /**
+     * Tests that the exception correctly carries each error code via getCode().
+     */
+    #[DataProvider('providerTestErrorCode')]
+    public function testErrorCode(int $code): void
+    {
+        $exception = new UnequalTablesException('message', $code);
+
+        self::assertSame($code, $exception->getCode());
+    }
+
+    /** @return array<string, array{0: int}> */
+    public static function providerTestErrorCode(): array
+    {
+        return [
+            'HEADER_MISMATCH' => [UnequalTablesException::HEADER_MISMATCH],
+            'CONTENT_MISMATCH' => [UnequalTablesException::CONTENT_MISMATCH],
+            'ROW_ORDER_MISMATCH' => [UnequalTablesException::ROW_ORDER_MISMATCH],
+            'STRUCTURAL_ERROR' => [UnequalTablesException::STRUCTURAL_ERROR],
+        ];
+    }
+
+    /**
+     * Tests that a wrapped previous exception is accessible via getPrevious().
+     */
+    public function testStructuralErrorPreservesPreviousException(): void
+    {
+        $previous = new RuntimeException('low-level failure');
+        $exception = new UnequalTablesException(
+            $previous->getMessage(),
+            UnequalTablesException::STRUCTURAL_ERROR,
+            $previous,
+        );
+
+        self::assertSame(UnequalTablesException::STRUCTURAL_ERROR, $exception->getCode());
+        self::assertSame($previous, $exception->getPrevious());
     }
 }


### PR DESCRIPTION
This PR simplifies the public exception contract for `TableEqualityAssertion::assert()` by exposing one exception type with explicit failure categories.

### Why
The previous behavior exposed mixed exception types (including low-level/third-party exceptions), which leaked implementation details and made consumer handling inconsistent.

### What changed
- Added public error-code constants on `UnequalTablesException`:
  - `HEADER_MISMATCH`
  - `CONTENT_MISMATCH`
  - `ROW_ORDER_MISMATCH`
  - `STRUCTURAL_ERROR`
- Updated `TableEqualityAssertion::assert()` to throw only `UnequalTablesException`.
- Replaced header mismatch `LogicException` with `UnequalTablesException::HEADER_MISMATCH`.
- Wrapped structural low-level failures as `UnequalTablesException::STRUCTURAL_ERROR`, preserving the original exception via `getPrevious()`.