### PR TITLE
Don't return a value from `TableEqualityAssertion::assert()`

### DIFF
--- a/docs/contract-surface.md
+++ b/docs/contract-surface.md
@@ -62,7 +62,7 @@ Notes:
 - The assertion compares Behat `TableNode` inputs.
 - `expectHeader(...)` controls header validation behavior.
 - `ignoreRowOrder()` and `respectRowOrder()` control order-sensitive diagnostics.
-- `assert()` returns `true` on success and throws on failure.
+- `assert()` returns void on success and throws on failure.
 
 ## Non-Contract Internals
 

--- a/src/TableEqualityAssertion.php
+++ b/src/TableEqualityAssertion.php
@@ -203,7 +203,7 @@ final class TableEqualityAssertion
      *
      * @throws \TravisCarden\BehatTableComparison\UnequalTablesException
      */
-    public function assert(): bool
+    public function assert(): void
     {
         try {
             $this->assertHeader();
@@ -215,8 +215,6 @@ final class TableEqualityAssertion
                 $e,
             );
         }
-
-        return true;
     }
 
     /**

--- a/tests/unit/TableEqualityAssertionTest.php
+++ b/tests/unit/TableEqualityAssertionTest.php
@@ -84,10 +84,8 @@ final class TableEqualityAssertionTest extends TestCase
         $left = new TableNode($left);
         $right = new TableNode($right);
 
-        $actual = (new TableEqualityAssertion($left, $right))
+        (new TableEqualityAssertion($left, $right))
             ->assert();
-
-        self::assertTrue($actual);
     }
 
     /**
@@ -280,11 +278,9 @@ final class TableEqualityAssertionTest extends TestCase
         $left = new TableNode(array_merge([$header], $rows));
         $right = new TableNode($rows);
 
-        $actual = (new TableEqualityAssertion($left, $right))
+        (new TableEqualityAssertion($left, $right))
             ->expectHeader($header)
             ->assert();
-
-        self::assertTrue($actual);
     }
 
     /**
@@ -335,11 +331,9 @@ final class TableEqualityAssertionTest extends TestCase
             ['id5', 'Label five', 'Fifth value', 'false'],
         ]);
 
-        $actual = (new TableEqualityAssertion($left, $right))
+        (new TableEqualityAssertion($left, $right))
             ->ignoreRowOrder()
             ->assert();
-
-        self::assertTrue($actual);
     }
 
     /**


### PR DESCRIPTION
There's no reason for `TableEqualityAssertion::assert()` to return a value. It's just an assertion.